### PR TITLE
fix graphcore customizations

### DIFF
--- a/common/common.tf
+++ b/common/common.tf
@@ -234,6 +234,7 @@ variable "service_resources" {
       cpu    = string
       memory = string
     })
+    storage = optional(string, null)
   }))
   // note that defaults are set in the locals block below so that we can merge
   default = {}

--- a/gradient-aws/common.tf
+++ b/gradient-aws/common.tf
@@ -234,6 +234,7 @@ variable "service_resources" {
       cpu    = string
       memory = string
     })
+    storage = optional(string, null)
   }))
   // note that defaults are set in the locals block below so that we can merge
   default = {}

--- a/gradient-metal-gc/common.tf
+++ b/gradient-metal-gc/common.tf
@@ -234,6 +234,7 @@ variable "service_resources" {
       cpu    = string
       memory = string
     })
+    storage = optional(string, null)
   }))
   // note that defaults are set in the locals block below so that we can merge
   default = {}

--- a/gradient-metal-gc/main.tf
+++ b/gradient-metal-gc/main.tf
@@ -138,8 +138,10 @@ module "gradient_processing" {
         "cpu"    = "1400m"
         "memory" = "30Gi"
       }
+      "storage" : "400Gi"
     }
   })
+  bad_nodes_interval = 0
 }
 
 

--- a/gradient-metal/common.tf
+++ b/gradient-metal/common.tf
@@ -234,6 +234,7 @@ variable "service_resources" {
       cpu    = string
       memory = string
     })
+    storage = optional(string, null)
   }))
   // note that defaults are set in the locals block below so that we can merge
   default = {}

--- a/gradient-ps-cloud/common.tf
+++ b/gradient-ps-cloud/common.tf
@@ -234,6 +234,7 @@ variable "service_resources" {
       cpu    = string
       memory = string
     })
+    storage = optional(string, null)
   }))
   // note that defaults are set in the locals block below so that we can merge
   default = {}

--- a/gradient-ps-cloud/resources.tf
+++ b/gradient-ps-cloud/resources.tf
@@ -127,6 +127,7 @@ locals {
         }
       },
       "vmstorage" = {
+        "storage" : "500Gi"
         "limits" = {
           "cpu"    = "12"
           "memory" = "50Gi"
@@ -208,6 +209,7 @@ locals {
         }
       },
       "vmstorage" = {
+        "storage" : "500Gi"
         "limits" = {
           "cpu"    = "3"
           "memory" = "12Gi"

--- a/gradient-ps-cloud/resources.tf
+++ b/gradient-ps-cloud/resources.tf
@@ -121,6 +121,7 @@ locals {
         }
       },
       "vmselect" = {
+        "storage" = "100Gi"
         "limits" = {
           "cpu"    = "6"
           "memory" = "15Gi"
@@ -203,6 +204,7 @@ locals {
         }
       },
       "vmselect" = {
+        "storage" = "30Gi"
         "limits" = {
           "cpu"    = "4"
           "memory" = "10Gi"

--- a/modules/gradient-processing/input.tf
+++ b/modules/gradient-processing/input.tf
@@ -459,5 +459,12 @@ variable "service_resources" {
       cpu    = string
       memory = string
     }), null)
+    storage = optional(string, null)
   }))
+}
+
+variable "bad_nodes_interval" {
+  description = "Interval to check for and cordon bad nodes in ms. Set to <= 0 to disable this feature."
+  type        = number
+  default     = 300000
 }

--- a/modules/gradient-processing/main.tf
+++ b/modules/gradient-processing/main.tf
@@ -253,6 +253,7 @@ resource "helm_release" "gradient_processing" {
       notebook_volume_type                                = var.notebook_volume_type
       admin_team_handle                                   = var.admin_team_handle
       resources                                           = local.resources
+      bad_nodes_interval                                  = var.bad_nodes_interval
     })
   ]
 }

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -497,9 +497,11 @@ victoria-metrics-k8s-stack:
           volumeClaimTemplate:
             spec:
               storageClassName: ${metrics_storage_class}
+              %{ if try(resources["vmselect"]["storage"], null) != null }
               resources:
                 requests:
-                  storage: 20Gi
+                  storage: resources["vmselect"]["storage"]
+              %{ endif }
       vmstorage:
         extraArgs:
           search.maxUniqueTimeseries: "6000000"

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -419,7 +419,7 @@ victoria-metrics-k8s-stack:
     spec:
       storage:
         storageClassName: ${metrics_storage_class}
-      %{ if can(resources["vmsingle"]["storage"], null) != null }
+      %{ if lookup(resources["vmsingle"], "storage", null) != null }
         resources:
           requests:
             storage: ${resources["vmsingle"]["storage"]
@@ -497,7 +497,7 @@ victoria-metrics-k8s-stack:
           volumeClaimTemplate:
             spec:
               storageClassName: ${metrics_storage_class}
-              %{ if can(resources["vmselect"]["storage"], null) != null }
+              %{ if lookup(resources["vmselect"], "storage", null) != null }
               resources:
                 requests:
                   storage: resources["vmselect"]["storage"]
@@ -522,13 +522,13 @@ victoria-metrics-k8s-stack:
           volumeClaimTemplate:
             spec:
               storageClassName: "${metrics_storage_class}"
-            %{ if can(resources["vmstorage"]["storage"], null) != null }
+            %{ if lookup(resources["vmstorage"], "storage", null) != null }
               resources:
                 requests:
                   storage: resources["vmstorage"]["storage"]
             %{ endif }
-        resources:
         %{ if try(resources["vmstorage"], null) != null }
+        resources:
           requests:
             cpu: ${resources["vmstorage"]["requests"]["cpu"]}
             memory: ${resources["vmstorage"]["requests"]["memory"]}

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -228,7 +228,8 @@ cluster-autoscaler:
     paperspace.com/pool-name: ${service_pool_name}
 
 dispatcher:
-  config: {}
+  config:
+    badNodesInterval: ${bad_nodes_interval}
   %{ if try(resources["dispatcher"], null) != null }
   resources:
     requests:
@@ -418,10 +419,10 @@ victoria-metrics-k8s-stack:
     spec:
       storage:
         storageClassName: ${metrics_storage_class}
-      %{ if is_public_cluster }
+      %{ if try(resources["vmsingle"]["storage"], null) != null }
         resources:
           requests:
-            storage: 400Gi
+            storage: ${resources["vmsingle"]["storage"]
       %{ endif }
       nodeSelector:
         paperspace.com/pool-name: ${prometheus_pool_name}
@@ -519,10 +520,10 @@ victoria-metrics-k8s-stack:
           volumeClaimTemplate:
             spec:
               storageClassName: "${metrics_storage_class}"
-            %{ if is_public_cluster }
+            %{ if try(resources["vmstorage"]["storage"], null) != null }
               resources:
                 requests:
-                  storage: 500Gi
+                  storage: resources["vmstorage"]["storage"]
             %{ endif }
         resources:
         %{ if try(resources["vmstorage"], null) != null }

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -419,7 +419,7 @@ victoria-metrics-k8s-stack:
     spec:
       storage:
         storageClassName: ${metrics_storage_class}
-      %{ if try(resources["vmsingle"]["storage"], null) != null }
+      %{ if can(resources["vmsingle"]["storage"], null) != null }
         resources:
           requests:
             storage: ${resources["vmsingle"]["storage"]
@@ -497,7 +497,7 @@ victoria-metrics-k8s-stack:
           volumeClaimTemplate:
             spec:
               storageClassName: ${metrics_storage_class}
-              %{ if try(resources["vmselect"]["storage"], null) != null }
+              %{ if can(resources["vmselect"]["storage"], null) != null }
               resources:
                 requests:
                   storage: resources["vmselect"]["storage"]
@@ -522,7 +522,7 @@ victoria-metrics-k8s-stack:
           volumeClaimTemplate:
             spec:
               storageClassName: "${metrics_storage_class}"
-            %{ if try(resources["vmstorage"]["storage"], null) != null }
+            %{ if can(resources["vmstorage"]["storage"], null) != null }
               resources:
                 requests:
                   storage: resources["vmstorage"]["storage"]

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -419,7 +419,7 @@ victoria-metrics-k8s-stack:
     spec:
       storage:
         storageClassName: ${metrics_storage_class}
-      %{ if try(resources["vmsingle"], null) != null and try(resources["vmsingle"]["storage"], null) != null }
+      %{ if try(resources["vmsingle"]["storage"], null) != null }
         resources:
           requests:
             storage: ${resources["vmsingle"]["storage"]}
@@ -497,7 +497,7 @@ victoria-metrics-k8s-stack:
           volumeClaimTemplate:
             spec:
               storageClassName: ${metrics_storage_class}
-              %{ if try(resources["vmselect"], null) != null and try(resources["vmselect"]["storage"], null) != null }
+              %{ if try(resources["vmselect"]["storage"], null) != null }
               resources:
                 requests:
                   storage: ${resources["vmselect"]["storage"]}
@@ -522,7 +522,7 @@ victoria-metrics-k8s-stack:
           volumeClaimTemplate:
             spec:
               storageClassName: "${metrics_storage_class}"
-            %{ if try(resources["vmstorage"], null) != null and try(resources["vmstorage"]["storage"], null) != null }
+            %{ if try(resources["vmstorage"]["storage"], null) != null }
               resources:
                 requests:
                   storage: ${resources["vmstorage"]["storage"]}

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -419,7 +419,7 @@ victoria-metrics-k8s-stack:
     spec:
       storage:
         storageClassName: ${metrics_storage_class}
-      %{ if lookup(resources["vmsingle"], "storage", null) != null }
+      %{ if try(resources["vmsingle"], null) != null and try(resources["vmsingle"]["storage"], null) != null }
         resources:
           requests:
             storage: ${resources["vmsingle"]["storage"]
@@ -497,7 +497,7 @@ victoria-metrics-k8s-stack:
           volumeClaimTemplate:
             spec:
               storageClassName: ${metrics_storage_class}
-              %{ if lookup(resources["vmselect"], "storage", null) != null }
+              %{ if try(resources["vmselect"], null) != null and try(resources["vmselect"]["storage"], null) != null }
               resources:
                 requests:
                   storage: resources["vmselect"]["storage"]
@@ -522,7 +522,7 @@ victoria-metrics-k8s-stack:
           volumeClaimTemplate:
             spec:
               storageClassName: "${metrics_storage_class}"
-            %{ if lookup(resources["vmstorage"], "storage", null) != null }
+            %{ if try(resources["vmstorage"], null) != null and try(resources["vmstorage"]["storage"], null) != null }
               resources:
                 requests:
                   storage: resources["vmstorage"]["storage"]

--- a/modules/gradient-processing/templates/values.yaml.tpl
+++ b/modules/gradient-processing/templates/values.yaml.tpl
@@ -422,7 +422,7 @@ victoria-metrics-k8s-stack:
       %{ if try(resources["vmsingle"], null) != null and try(resources["vmsingle"]["storage"], null) != null }
         resources:
           requests:
-            storage: ${resources["vmsingle"]["storage"]
+            storage: ${resources["vmsingle"]["storage"]}
       %{ endif }
       nodeSelector:
         paperspace.com/pool-name: ${prometheus_pool_name}
@@ -500,7 +500,7 @@ victoria-metrics-k8s-stack:
               %{ if try(resources["vmselect"], null) != null and try(resources["vmselect"]["storage"], null) != null }
               resources:
                 requests:
-                  storage: resources["vmselect"]["storage"]
+                  storage: ${resources["vmselect"]["storage"]}
               %{ endif }
       vmstorage:
         extraArgs:
@@ -525,7 +525,7 @@ victoria-metrics-k8s-stack:
             %{ if try(resources["vmstorage"], null) != null and try(resources["vmstorage"]["storage"], null) != null }
               resources:
                 requests:
-                  storage: resources["vmstorage"]["storage"]
+                  storage: ${resources["vmstorage"]["storage"]}
             %{ endif }
         %{ if try(resources["vmstorage"], null) != null }
         resources:


### PR DESCRIPTION
* Allow for victoria disk sizes to come through the resources
  abstraction allowing graphcore to have a large vmsingle disk
* Turn off the bad nodes detector in graphcore. It only makes sense with
  asg backed machines