### PR TITLE
fix(ps-cloud): make guest health checks more resilient SIT-372

### DIFF
--- a/gradient-ps-cloud/files/linux-guest-health.sh
+++ b/gradient-ps-cloud/files/linux-guest-health.sh
@@ -21,7 +21,8 @@ if [ ! -f "$GUEST_OUTPUT" ]; then
   fi
 fi
 
-if find "$GUEST_OUTPUT" -mmin -5 | read -r; then
+# update interval is 60 minutes on the health reporter
+if find "$GUEST_OUTPUT" -mmin -61 | read -r; then
   echo "Guest health output too old"
   exit $NONOK
 fi


### PR DESCRIPTION
Currently if the system never runs the health check the script will
always return unknown meaning the node is never flagged as unhealthy.

Additionally if the system goes readonly then the last output of the
guest health will be read in perpuitity. We want to make sure we are
only getting fresh data.
