### PR TITLE
fix(ps-cloud): dont rely on non-present uptime binary SIT-372

### DIFF
--- a/gradient-ps-cloud/bin/run
+++ b/gradient-ps-cloud/bin/run
@@ -24,6 +24,8 @@ terraform init -upgrade
 terraform workspace new "$TF_VAR_cluster_handle" || true
 terraform workspace select "$TF_VAR_cluster_handle"
 
+sleep infinity
+
 export PAPERSPACE_API_KEY="$TF_VAR_admin_user_api_key"
 export PAPERSPACE_API_HOST="$TF_VAR_api_host"
 export PAPERSPACE_REGION="$TF_VAR_region"

--- a/gradient-ps-cloud/bin/run
+++ b/gradient-ps-cloud/bin/run
@@ -24,8 +24,6 @@ terraform init -upgrade
 terraform workspace new "$TF_VAR_cluster_handle" || true
 terraform workspace select "$TF_VAR_cluster_handle"
 
-sleep infinity
-
 export PAPERSPACE_API_KEY="$TF_VAR_admin_user_api_key"
 export PAPERSPACE_API_HOST="$TF_VAR_api_host"
 export PAPERSPACE_REGION="$TF_VAR_region"

--- a/gradient-ps-cloud/files/linux-guest-health.sh
+++ b/gradient-ps-cloud/files/linux-guest-health.sh
@@ -9,9 +9,22 @@ readonly UNKNOWN=2
 readonly GUEST_OUTPUT="$1"
 readonly CHECK="$2"
 
+uptime_seconds=$(uptime | awk -F' ' '{print $3}' | awk -F':' '{print $1*3600 + $2*60}')
+
 if [ ! -f "$GUEST_OUTPUT" ]; then
-  echo "No guest health output found"
-  exit $UNKNOWN
+  if [ "$uptime_seconds" -gt 300 ]; then
+    echo "Guest health output not found and uptime > 5 minutes"
+    exit $NONOK
+  else
+    echo "Still waiting for initial guest health output"
+    exit $UNKNOWN
+  fi
+fi
+
+# update interval is 60 minutes on the health reporter
+if find "$GUEST_OUTPUT" -mmin -61 | read -r; then
+  echo "Guest health output too old"
+  exit $NONOK
 fi
 
 error=$(jq -r "try .errors.\"$CHECK\" | join(\",\")" "$GUEST_OUTPUT")

--- a/gradient-ps-cloud/files/linux-guest-health.sh
+++ b/gradient-ps-cloud/files/linux-guest-health.sh
@@ -9,7 +9,7 @@ readonly UNKNOWN=2
 readonly GUEST_OUTPUT="$1"
 readonly CHECK="$2"
 
-uptime_seconds=$(uptime | awk -F' ' '{print $3}' | awk -F':' '{print $1*3600 + $2*60}')
+uptime_seconds=$(cut -d'.' -f1 < /proc/uptime)
 
 if [ ! -f "$GUEST_OUTPUT" ]; then
   if [ "$uptime_seconds" -gt 300 ]; then

--- a/gradient-ps-cloud/files/linux-guest-health.sh
+++ b/gradient-ps-cloud/files/linux-guest-health.sh
@@ -22,7 +22,7 @@ if [ ! -f "$GUEST_OUTPUT" ]; then
 fi
 
 # update interval is 60 minutes on the health reporter
-if find "$GUEST_OUTPUT" -mmin -61 | read -r; then
+if [ -z "$(find "$GUEST_OUTPUT" -mmin -61)" ]; then
   echo "Guest health output too old"
   exit $NONOK
 fi

--- a/gradient-ps-cloud/node_problem_detector.tf
+++ b/gradient-ps-cloud/node_problem_detector.tf
@@ -9,7 +9,7 @@ module "node_problem_detector" {
 
   draino_flags = {
     skip_drain = true
-    node_label_expr = "metadata.labels['node-role.kubernetes.io/worker'] == 'true'"
+    node_label_expr = "metadata.labels['node-role.kubernetes.io/worker'] == 'true' && metadata.labels['paperspace.com/pool-name'] != 'lb' && metadata.labels['paperspace.com/pool-name'] != 'services-small'"
   }
 
   draino_node_selector = {

--- a/gradient-ps-cloud/node_problem_detector.tf
+++ b/gradient-ps-cloud/node_problem_detector.tf
@@ -9,6 +9,7 @@ module "node_problem_detector" {
 
   draino_flags = {
     skip_drain = true
+    node_label_expr = "metadata.labels['node-role.kubernetes.io/worker'] == 'true'"
   }
 
   draino_node_selector = {


### PR DESCRIPTION
- Revert "Revert "fix(ps-cloud): make guest health checks more resilient SIT-372 (#447)" (#452)"
- fix(ps-cloud): dont rely on non-present uptime binary SIT-372
