### PR TITLE
chore: increase dispatcher resources

### DIFF
--- a/gradient-ps-cloud/resources.tf
+++ b/gradient-ps-cloud/resources.tf
@@ -8,8 +8,8 @@ locals {
     }
     "dispatcher" = {
       "limits" = {
-        "cpu"    = "1000m"
-        "memory" = "2Gi"
+        "cpu"    = "2000m"
+        "memory" = "4Gi"
       },
     },
     "gradient-operator-controller" = {
@@ -30,7 +30,7 @@ locals {
         "memory" = "1Gi"
       }
     },
-    "gradient-dispatcher-notifier" = {
+    "dispatcher-notifier" = {
       "limits" = {
         "cpu"    = "1"
         "memory" = "768Mi"


### PR DESCRIPTION
Health check fails with exactly 1 cpu. While js code runs single threaded many IO operations do not, giving node exactly 1 cpu can cause stalls.