### PR TITLE
fix(ps-cloud): default to templated pool name

### DIFF
--- a/gradient-ps-cloud/main.tf
+++ b/gradient-ps-cloud/main.tf
@@ -664,7 +664,7 @@ resource "paperspace_script" "autoscale" {
   script_text = templatefile("${path.module}/templates/setup-script.tpl", {
     kind                         = "autoscale_worker"
     gpu_enabled                  = each.value.type == "gpu"
-    pool_name                    = each.key
+    pool_name                    = ""
     pool_type                    = each.value.type
     rancher_command              = rancher2_cluster.main.cluster_registration_token[0].node_command
     ssh_public_key               = tls_private_key.ssh_key.public_key_openssh

--- a/gradient-ps-cloud/templates/setup-script.tpl
+++ b/gradient-ps-cloud/templates/setup-script.tpl
@@ -51,7 +51,10 @@ MACHINE_JSON=$(curl -s https://metadata.paperspace.com/meta-data/machine)
 export MACHINE_ID=$(echo "$MACHINE_JSON" | grep id | sed 's/^.*: "\(.*\)".*/\1/')
 export MACHINE_PRIVATE_IP=$(echo "$MACHINE_JSON" | grep privateIpAddress | sed 's/^.*: "\(.*\)".*/\1/')
 export MACHINE_PUBLIC_IP=$(echo "$MACHINE_JSON" | grep publicIpAddress | sed 's/^.*: "\(.*\)".*/\1/')
-export MACHINE_POOL=$(echo "$MACHINE_JSON" | grep machineType| sed 's/^.*: "\(.*\)".*/\1/')
+export MACHINE_POOL="${pool_name}"
+if [ -z "${MACHINE_POOL:-} ]; then
+    export MACHINE_POOL=$(echo "$MACHINE_JSON" | grep machineType| sed 's/^.*: "\(.*\)".*/\1/')
+fi
 GPU_TYPE=$(echo "$MACHINE_JSON"| grep gpu\" | sed 's/^.*: "\(.*\)".*/\1/')
 [ "$GPU_TYPE" = 'None' ] && MACHINE_POOL_TYPE=cpu || MACHINE_POOL_TYPE=gpu
 

--- a/gradient-ps-cloud/templates/setup-script.tpl
+++ b/gradient-ps-cloud/templates/setup-script.tpl
@@ -52,7 +52,7 @@ export MACHINE_ID=$(echo "$MACHINE_JSON" | grep id | sed 's/^.*: "\(.*\)".*/\1/'
 export MACHINE_PRIVATE_IP=$(echo "$MACHINE_JSON" | grep privateIpAddress | sed 's/^.*: "\(.*\)".*/\1/')
 export MACHINE_PUBLIC_IP=$(echo "$MACHINE_JSON" | grep publicIpAddress | sed 's/^.*: "\(.*\)".*/\1/')
 export MACHINE_POOL="${pool_name}"
-if [ -z "${MACHINE_POOL:-} ]; then
+if [ -z "$${MACHINE_POOL:-} ]; then
     export MACHINE_POOL=$(echo "$MACHINE_JSON" | grep machineType| sed 's/^.*: "\(.*\)".*/\1/')
 fi
 GPU_TYPE=$(echo "$MACHINE_JSON"| grep gpu\" | sed 's/^.*: "\(.*\)".*/\1/')


### PR DESCRIPTION
Pools like `service` need to override the vm type label as the pool otherwise cluster bootstrapping gets confused.